### PR TITLE
Add Javadoc generation check and update deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,17 @@ jobs:
           mvn versions:set -DnewVersion=$UPDATE_VERSION
           mvn versions:update-child-modules
           mvn clean deploy -s ci_settings.xml
+          
           mvn javadoc:javadoc
+          
+          # Verify if Javadoc files are generated
+          if [ ! -d "sidebar-base/target/reports/apidocs" ]; then
+            echo "Javadoc directory not found!"
+            exit 1
+          fi
+          
           sudo apt install -y -qq lftp
-          lftp -c "set ftp:ssl-allow no; open -u $J_DOCS_USER,$J_DOCS_PASS javadocs.andrei1058.dev; mirror -Rev sidebar-base/target/site/apidocs ./SidebarLib  --ignore-time --parallel=10 --exclude-glob .git* --exclude .git/"
+          lftp -c "set ftp:ssl-allow no; open -u $J_DOCS_USER,$J_DOCS_PASS javadocs.andrei1058.dev; mirror -Rev sidebar-base/target/reports/apidocs ./SidebarLib  --ignore-time --parallel=10 --exclude-glob .git* --exclude .git/"
           curl -X PUT https://api.andrei1058.dev/v1/resources/4/versioning/commit -H "Accept: application/json" -H "Authorization: Bearer ${{ secrets.ANDEV_API_TOKEN }}" -H "Content-Type: application/json" --data '{"confirmation": true}' >> version.json
           echo "UPDATE_VERSION=$UPDATE_VERSION" >> $GITHUB_ENV
       - name: Create Tag


### PR DESCRIPTION
Ensure Javadoc files are generated before deployment to prevent missing documentation. Updated the file path for Javadoc in the deployment process to match the new directory structure.