### PR TITLE
Handle null title in Sidebar creation

### DIFF
--- a/sidebar-base/src/main/java/com/andrei1058/spigot/sidebar/SidebarManager.java
+++ b/sidebar-base/src/main/java/com/andrei1058/spigot/sidebar/SidebarManager.java
@@ -91,11 +91,16 @@ public class SidebarManager {
      */
     @SuppressWarnings("unused")
     public Sidebar createSidebar(
-            SidebarLine title,
+            @Nullable SidebarLine title,
             @NotNull Collection<SidebarLine> lines,
             Collection<PlaceholderProvider> placeholderProviders) {
         lines.forEach(sidebarLine -> SidebarLine.markHasPlaceholders(sidebarLine, placeholderProviders));
-        return sidebarProvider.createSidebar(title, lines, placeholderProviders);
+        return sidebarProvider.createSidebar(null == title ? new SidebarLine() {
+            @Override
+            public @NotNull String getLine() {
+                return "";
+            }
+        } : title, lines, placeholderProviders);
     }
 
     /**


### PR DESCRIPTION
Updated SidebarManager to handle null titles by providing a default empty SidebarLine. This prevents potential null pointer exceptions and ensures smoother Sidebar creation.